### PR TITLE
Add HTTP support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,4 +4,5 @@ go:
 
 script:
     - go test -v ./...
-    - cd examples/echoServer && go build
+    - cd $HOME/gopath/src/github.com/JoeReid/fastTCP/examples/echoServer && go build
+    - cd $HOME/gopath/src/github.com/JoeReid/fastTCP/examples/http && go build

--- a/examples/http/http.go
+++ b/examples/http/http.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"github.com/JoeReid/fastTCP"
+	fastHTTP "github.com/JoeReid/fastTCP/http"
+	"net/http"
+)
+
+func httpHandler(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, "HTTP test")
+}
+
+func main() {
+	httpServer := fastHTTP.NewHTTPServer(
+		http.HandlerFunc(httpHandler),
+	)
+
+	tcpServer := fastTCP.NewServer(
+		":6543",
+		httpServer.NewConn,
+		fastTCP.TCPOptions{},
+	)
+
+	err := tcpServer.ListenTCP()
+	if err != nil {
+		panic(err)
+	}
+}

--- a/http/http.go
+++ b/http/http.go
@@ -1,0 +1,99 @@
+package http
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httputil"
+)
+
+type HTTPServer struct {
+	handler http.Handler
+}
+
+func NewHTTPServer(h http.Handler) *HTTPServer {
+	return &HTTPServer{h}
+}
+
+func (h *HTTPServer) NewConn(tcp io.ReadWriter) {
+	br := bufio.NewReader(tcp)
+
+	req, err := http.ReadRequest(br)
+	if err != nil {
+		return
+	}
+
+	rw := newFastResponseWriter(req, tcp)
+	h.handler.ServeHTTP(rw, req)
+}
+
+func newFastResponseWriter(req *http.Request, conn io.Writer) http.ResponseWriter {
+	return &fastResponseWriter{
+		response: &http.Response{
+			Header:           http.Header(make(map[string][]string)),
+			Proto:            req.Proto,
+			ProtoMajor:       req.ProtoMajor,
+			ProtoMinor:       req.ProtoMinor,
+			TransferEncoding: req.TransferEncoding,
+		},
+		conn: conn,
+	}
+}
+
+type fastBody struct {
+	buff   *bytes.Buffer
+	closed bool
+}
+
+func (f *fastBody) Read(b []byte) (int, error) {
+	if f.closed {
+		return 0, errors.New("Closed")
+	}
+	return f.buff.Read(b)
+}
+
+func (f *fastBody) Close() error {
+	if f.closed {
+		return errors.New("Error already closed")
+	}
+
+	f.closed = true
+	return nil
+}
+
+type fastResponseWriter struct {
+	response *http.Response
+	conn     io.Writer
+}
+
+func (f *fastResponseWriter) Header() http.Header {
+	return f.response.Header
+}
+
+func (f *fastResponseWriter) Write(bdy []byte) (int, error) {
+	if f.response.StatusCode == 0 {
+		f.WriteHeader(http.StatusOK)
+	}
+
+	f.response.ContentLength = int64(len(bdy))
+	f.response.Body = &fastBody{buff: bytes.NewBuffer(bdy)}
+
+	b, err := httputil.DumpResponse(f.response, true)
+	if err != nil {
+		return 0, err
+	}
+
+	_, err = f.conn.Write(b)
+	if err != nil {
+		return 0, err
+	}
+
+	return len(bdy), nil
+}
+
+func (f *fastResponseWriter) WriteHeader(h int) {
+	f.response.StatusCode = h
+	f.response.Status = http.StatusText(h)
+}

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -17,7 +17,7 @@ func TestHTTP(t *testing.T) {
 		}),
 	)
 
-	server := fastTCP.NewServer(":6543", hs.NewConn, fastTCP.TCPOptions{})
+	server := fastTCP.NewServer(":6544", hs.NewConn, fastTCP.TCPOptions{})
 	go func() {
 		err := server.ListenTCP()
 		if err != nil {
@@ -27,7 +27,7 @@ func TestHTTP(t *testing.T) {
 
 	time.Sleep(50 * time.Millisecond)
 
-	resp, err := goHTTP.Get("http://localhost:6543/")
+	resp, err := goHTTP.Get("http://localhost:6544/")
 	if err != nil {
 		t.Log(err)
 	}

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -1,0 +1,41 @@
+package http_test
+
+import (
+	"fmt"
+	"github.com/JoeReid/fastTCP"
+	"github.com/JoeReid/fastTCP/http"
+	"io/ioutil"
+	goHTTP "net/http"
+	"testing"
+	"time"
+)
+
+func TestHTTP(t *testing.T) {
+	hs := http.NewHTTPServer(
+		goHTTP.HandlerFunc(func(rw goHTTP.ResponseWriter, r *goHTTP.Request) {
+			fmt.Fprint(rw, "Test")
+		}),
+	)
+
+	server := fastTCP.NewServer(":6543", hs.NewConn, fastTCP.TCPOptions{})
+	go func() {
+		err := server.ListenTCP()
+		if err != nil {
+			panic(err)
+		}
+	}()
+
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := goHTTP.Get("http://localhost:6543/")
+	if err != nil {
+		t.Log(err)
+	}
+
+	buff, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Log(err)
+	}
+
+	t.Logf("%s", buff)
+}

--- a/http/http_test.go
+++ b/http/http_test.go
@@ -10,12 +10,26 @@ import (
 	"time"
 )
 
-func TestHTTP(t *testing.T) {
-	hs := http.NewHTTPServer(
-		goHTTP.HandlerFunc(func(rw goHTTP.ResponseWriter, r *goHTTP.Request) {
-			fmt.Fprint(rw, "Test")
-		}),
-	)
+func handleOK(w goHTTP.ResponseWriter, r *goHTTP.Request) {
+	w.WriteHeader(200)
+	fmt.Fprint(w, "Status OK")
+}
+
+func handleNotFound(w goHTTP.ResponseWriter, r *goHTTP.Request) {
+	w.WriteHeader(404)
+	fmt.Fprint(w, "Status Not Found")
+}
+
+func handleHeader(k, v string) func(w goHTTP.ResponseWriter, r *goHTTP.Request) {
+	return func(w goHTTP.ResponseWriter, r *goHTTP.Request) {
+		w.WriteHeader(200)
+		w.Header().Set(k, v)
+		fmt.Fprint(w, "Status OK, with custom headers")
+	}
+}
+
+func TestHTTPOK(t *testing.T) {
+	hs := http.NewHTTPServer(goHTTP.HandlerFunc(handleOK))
 
 	server := fastTCP.NewServer(":6544", hs.NewConn, fastTCP.TCPOptions{})
 	go func() {
@@ -24,17 +38,91 @@ func TestHTTP(t *testing.T) {
 			panic(err)
 		}
 	}()
+	defer server.Stop()
 
 	time.Sleep(50 * time.Millisecond)
 
 	resp, err := goHTTP.Get("http://localhost:6544/")
 	if err != nil {
-		t.Log(err)
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected 200OK got %v", resp.StatusCode)
 	}
 
 	buff, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		t.Log(err)
+		t.Fatal(err)
+	}
+
+	t.Logf("%s", buff)
+}
+
+func TestHTTPNotFound(t *testing.T) {
+	hs := http.NewHTTPServer(goHTTP.HandlerFunc(handleNotFound))
+
+	server := fastTCP.NewServer(":6544", hs.NewConn, fastTCP.TCPOptions{})
+	go func() {
+		err := server.ListenTCP()
+		if err != nil {
+			panic(err)
+		}
+	}()
+	defer server.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := goHTTP.Get("http://localhost:6544/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 404 {
+		t.Fatalf("Expected 404 got %v", resp.StatusCode)
+	}
+
+	buff, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Logf("%s", buff)
+}
+
+func TestHTTPHeader(t *testing.T) {
+	hs := http.NewHTTPServer(goHTTP.HandlerFunc(handleHeader("TestHeader", "FooBar")))
+
+	server := fastTCP.NewServer(":6544", hs.NewConn, fastTCP.TCPOptions{})
+	go func() {
+		err := server.ListenTCP()
+		if err != nil {
+			panic(err)
+		}
+	}()
+	defer server.Stop()
+
+	time.Sleep(50 * time.Millisecond)
+
+	resp, err := goHTTP.Get("http://localhost:6544/")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if resp.StatusCode != 200 {
+		t.Fatalf("Expected 200OK got %v", resp.StatusCode)
+	}
+
+	if resp.Header.Get("TestHeader") != "FooBar" {
+		t.Fatalf(
+			"Expected header 'TestHeader' to be set to 'FooBar' but got '%v'",
+			resp.Header.Get("TestHeader"),
+		)
+	}
+
+	buff, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
 	}
 
 	t.Logf("%s", buff)


### PR DESCRIPTION
Added an HTTP sub system that runs on the current TCP io.Readwriter system. Integrates with the standard lib http.Handler objects for ease of use.

Added an example of use in the examples folder.

Added tests for different status codes and headers.